### PR TITLE
Switch to a CDN that supports IPv6

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -256,6 +256,12 @@ optional.
   files to be loaded.  They will be referenced at the bottom of
   ``base.html``, after any default script files.
 
+``CDN_DICT``
+  Allows to override the CDNs for the used JS libraries. The dictionary
+  must include the keys bootstrap, jquery and awesome. It defaults to
+  the cdnjs.com public CDN because that CDN provides all the libraries,
+  is popular and supports IPv6.
+
 ``ARCHIVES_URL``
   URL of archives page.  Default is ``archives.html``.  If you're modifying
   ``ARCHIVES_SAVE_AS`` in your pelicanconf.py then you'll probably need to

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,5 +1,12 @@
 <!DOCTYPE html>
 <html lang="en">
+  {% if not CDN_DICT %}
+    {% set CDN_DICT = {
+       'bootstrap': 'https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap',
+       'jquery'   : 'https://cdnjs.cloudflare.com/ajax/libs/jquery',
+       'awesome'  : 'https://cdnjs.cloudflare.com/ajax/libs/font-awesome',
+       } %}
+  {% endif %}
   <head>
     <meta charset="utf-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
@@ -33,12 +40,12 @@
         <link rel="stylesheet" href="{{ SITEURL }}/theme/css/{{ BOOTSTRAP_STYLESHEET }}" />
       {% else %}
         <link rel="stylesheet"
-              href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css"
+              href="{{CDN_DICT['bootstrap']}}/3.3.7/css/bootstrap.min.css"
               integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u"
               crossorigin="anonymous" />
       {% endif %}
       <link rel="stylesheet"
-            href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css"
+            href="{{CDN_DICT['awesome']}}/4.7.0/css/font-awesome.min.css"
             integrity="sha384-wvfXpqpZZVQGK6TAh5PVlGOfQNHSoD2xbE+QkPxCAFlNEevoEH3Sl0sibVcOQVnN"
             crossorigin="anonymous">
     {% endif %}
@@ -177,8 +184,8 @@
 
     <!-- javascript -->
     {% if not SKIP_DEFAULT_JS %}   
-    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js" integrity="sha384-nvAa0+6Qg9clwYCGGPpDQLVpLNn0fRaROjHqs13t4Ggj3Ez50XnGQqc/r8MhnRDZ" crossorigin="anonymous"></script>
-    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"
+    <script src="{{CDN_DICT['jquery']}}/1.12.4/jquery.min.js" integrity="sha384-nvAa0+6Qg9clwYCGGPpDQLVpLNn0fRaROjHqs13t4Ggj3Ez50XnGQqc/r8MhnRDZ" crossorigin="anonymous"></script>
+    <script src="{{CDN_DICT['bootstrap']}}/3.3.7/js/bootstrap.min.js"
             integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa"
             crossorigin="anonymous"></script>
     {% endif %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -54,11 +54,6 @@
       <link rel="stylesheet" href="{{ SITEURL }}/theme/css/{{ css }}" />
     {% endfor %}
 
-    <!--[if lt IE 9]>
-      <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js" integrity="sha384-FFgGfda92tXC8nCNOxrCQ3R8x1TNkMFqDZVQdDaaJiiVbjkPBXIJBx0o7ETjy8Bh" crossorigin="anonymous"></script>
-      <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js" integrity="sha384-ZoaMbDF+4LeFxg6WdScQ9nnR1QC2MIRxA1O9KWEXQwns1G8UNyIEZIQidzb0T1fo" crossorigin="anonymous"></script>
-    <![endif]-->
-
     <link rel="shortcut icon" href="{{ SITEURL }}/{{ FAVICON|default('favicon.ico') }}" />
     {% if CUSTOM_HTML_HEAD %}
     {% include "includes/" + CUSTOM_HTML_HEAD %}


### PR DESCRIPTION
See also the commit messages for details.

Summary: bootstrap-cdn doesn't support IPv6, thus the switch (cf. https://github.com/MaxCDN/bootstrap-cdn/issues/533). Also removed an older pre-IE9 workaround to reduce the number of possible JS dependencies. As part of the change, the choice of CDN can easily be overridden via a config variable and the multiple CDNs are consolidated into one to improve the load time.